### PR TITLE
Add express request handling logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,29 @@
+//TODO: Use dotenv for api route
+const express = require('express');
+const bodyParser = require('body-parser');
+const app = express();
+const db = require("./sqlQueries");
+
+const port = 3000;
+
+const api_route = '';
+
+app.use(bodyParser.json());
+app.use(
+  bodyParser.urlencoded({
+    extended: true,
+  })
+)
+
+app.get('/', (request, response) => {
+  response.json({ info: 'Node.js, Express, and Postgres API' });
+})
+
+app.get(`/${api_route}`, db.getRequest);
+app.post(`/${api_route}`, db.postRequest);
+app.put(`/${api_route}`, db.putRequest)
+app.delete(`/${api_route}`, db.deleteRequest);
+
+app.listen(port, () => {
+    console.log(`App listening on port ${port}.`);
+});

--- a/sqlQueries.js
+++ b/sqlQueries.js
@@ -1,0 +1,63 @@
+//TODO: use dotenv for db connection strings
+const Pool = require('pg').Pool;
+const sqlGenerator = require('./generateSqlQueries')
+
+const pool = new Pool({
+    user: '',
+    host: '',
+    database: '',
+    password: '',
+    port: 5432
+});
+
+function queryTable(query, response) {
+    console.log(`Executing the following SQL query: <${query}>`);
+    pool.query(selectQuery, (error, results) => {
+        if (error) {
+            throw error;
+        }
+        response.status(200).json(results.rows);
+    });
+}
+
+const getRequest = (request, response) => {
+    const tableName = request.query.tableName;
+    const tableColumns = request.query.tableColumns;
+    const where = request.query.where;
+    const orderBy = request.query.orderBy;
+
+    selectQuery = sqlGenerator.generateSelectQuery(tableName, tableColumns, where, orderBy);
+    queryTable(selectQuery, response);
+};
+
+const postRequest = (request, response) => {
+    const tableName = request.body.params.tableName;
+    const tableData = request.body.params.tableData;
+
+    insertQuery = sqlGenerator.generateInsertQuery(tableName, tableData);
+    queryTable(insertQuery, response);
+};
+
+const putRequest = (request, response) => {
+    const tableName = request.body.params.tableName;
+    const sets = request.body.params.sets;
+    const where = request.body.params.where;
+
+    updateQuery = sqlGenerator.generateUpdateQuery(tableName, sets, where);
+    queryTable(updateQuery, response);
+};
+
+const deleteRequest = (request, response) => {
+    const tableName = request.query.tableName;
+    const where = request.query.where;
+
+    deleteQuery = sqlGenerator.generateDeleteQuery(tableName, where);
+    queryTable(deleteQuery, response);
+};
+
+module.exports = {
+    getRequest,
+    postRequest,
+    putRequest,
+    deleteRequest
+};


### PR DESCRIPTION
Add logic to accept CRUD requests on server. 

API request -> PostgreSQL operations are as follows:
1. Create (HTTP POST): SQL INSERT INTO statement
2. Read (HTTP GET): SQL SELECT statement
3. Update (HTTP PUT): SQL UPDATE statement
4. Delete (HTTP DELETE): SQL DELETE statement

Functionality currently assumes database is already created locally.